### PR TITLE
Migrate to new lecturers schema

### DIFF
--- a/readme.toml
+++ b/readme.toml
@@ -4,28 +4,26 @@ course_code = "AUTO3004"
 
 description = "系统建模与仿真课程资料，包含授课教师评价、课程内容分析及考试攻略。"
 
-[[lecturers]]
+[lecturers]
+[[lecturers.items]]
 name = "李衍杰"
 
-[[lecturers.reviews]]
+[[lecturers.items.reviews]]
 content = """
 授课风格：轻松愉快，稍显啰嗦，实验课会带领大家写代码并亲自检查，偶尔点名。
 是否需要认真听讲做笔记：正常听课，考前复习。
 听课建议：注意重点强调的最小二乘，PPT 标红简答，龙格库塔法计算。
 """
 author = { name = "phychi", link = "https://github.com/phychi", date = "2023-11" }
-
-[[lecturers]]
+[[lecturers.items]]
 name = "李芃"
 
-[[lecturers.reviews]]
+[[lecturers.items.reviews]]
 content = """
 授课风格：念 ppt。
 听课建议：正常听课，考前复习。
 """
 author = { name = "phychi", link = "https://github.com/phychi", date = "2023-11" }
-
-
 [[sections]]
 title = "课程内容"
 


### PR DESCRIPTION
Automated migration from legacy `[[lecturers]]` to new `[lecturers]` + `[[lecturers.items]]` + `[[lecturers.items.reviews]]` schema.

This is required for pr-server compatibility.